### PR TITLE
fix: avoid exception when calling :Reject on last element

### DIFF
--- a/lua/qf_helper.lua
+++ b/lua/qf_helper.lua
@@ -173,6 +173,9 @@ M.cmd_filter = function(keep, range_start, range_end)
     end
   end
   util.set_list(qftype, newlist)
+  if #newlist == 0 then
+    return
+  end
   lnum = math.min(math.max(1, lnum), #newlist)
   vim.api.nvim_win_set_cursor(0, { lnum, cursor[2] })
 end


### PR DESCRIPTION
This commit adds array length check gate before setting the cursor position on list entry removal with `:Reject` command. It allows to avoid the following exception which gets produced otherwise:
```
E5108: Error executing lua .../qf_helper.nvim/lua/qf_helper.lua:180: Cursor position outside buffer
```